### PR TITLE
netsh: profiles: use line no and regex to parse "Key contents"

### DIFF
--- a/src/core.bat
+++ b/src/core.bat
@@ -56,7 +56,7 @@ echo # %appname% %appvers% - %appstat%
 echo # by %dev%
 echo # %divider%
 echo # Checking for wireless interface...
-netsh wlan show profiles | findstr "All"
+netsh wlan show profiles | findstr /R /C:"[ ]:[ ]"
 if %errorlevel%==1 goto fail3
 cls
 title %appname% %appvers% - %appstat% [Automated Mode]
@@ -66,7 +66,7 @@ echo # %appname% %appvers% - %appstat%
 echo # by %dev%
 echo # %divider%
 echo # Checking for wireless interface...
-netsh wlan show profiles | findstr "All" > temp.txt
+netsh wlan show profiles | findstr /R /C:"[ ]:[ ]" > temp.txt
 echo # Available SSID in this Machine
 type temp.txt
 echo # %divider%
@@ -128,7 +128,7 @@ rem =============================
 rem Manual Mode: Confirm Scan
 rem =============================
 :manualConfirm
-netsh wlan show profiles | findstr "All"
+netsh wlan show profiles | findstr /R /C:"[ ]:[ ]"
 if %errorlevel%==1 goto fail3
 goto mainualContinue
 

--- a/wifi-passview-v2.5.5.bat
+++ b/wifi-passview-v2.5.5.bat
@@ -87,7 +87,7 @@ echo # %appname% %appvers% - %appstat%
 echo # by %dev%
 echo # %divider%
 echo # Checking for wireless interface...
-netsh wlan show profiles | findstr "All"
+netsh wlan show profiles | findstr /R /C:"[ ]:[ ]"
 if %errorlevel%==1 goto fail3
 cls
 title %appname% %appvers% - %appstat% [Automated Mode]
@@ -97,7 +97,7 @@ echo # %appname% %appvers% - %appstat%
 echo # by %dev%
 echo # %divider%
 echo # Checking for wireless interface...
-netsh wlan show profiles | findstr "All" > temp.txt
+netsh wlan show profiles | findstr /R /C:"[ ]:[ ]" > temp.txt
 echo # Available SSID in this Machine
 type temp.txt
 echo # %divider%
@@ -107,7 +107,7 @@ echo setlocal enabledelayedexpansion >> helper.bat
 echo for /f "tokens=5*" %%%%i in (temp.txt) do ( set val=%%%%i %%%%j >> helper.bat
 echo if "!val:~-1!" == " " set val=!val:~0,-1! >> helper.bat
 echo echo !val! ^>^> final.txt) >> helper.bat
-echo for /f "tokens=*" %%%%i in (final.txt) do @echo SSID: %%%%i ^>^> creds.txt ^& echo # %tempdivider% ^>^> creds.txt ^& netsh wlan show profiles name=%%%%i key=clear ^| findstr /c:"Key Content" ^>^> creds.txt ^& echo # %tempdivider% ^>^> creds.txt ^& echo # Key content is the password of your target SSID. ^>^> creds.txt ^& echo # %tempdivider% ^>^> creds.txt >> helper.bat
+echo for /f "tokens=*" %%%%i in (final.txt) do @echo SSID: %%%%i ^>^> creds.txt ^& echo # %tempdivider% ^>^> creds.txt ^& netsh wlan show profiles name=%%%%i key=clear ^| findstr /N /R /C:":" ^| findstr 33 ^>^> creds.txt ^& echo # %tempdivider% ^>^> creds.txt ^& echo # Key content is the password of your target SSID. ^>^> creds.txt ^& echo # %tempdivider% ^>^> creds.txt >> helper.bat
 echo del /q temp.txt final.txt >> helper.bat
 echo exit >> helper.bat
 echo # Done...
@@ -159,7 +159,7 @@ rem =============================
 rem Manual Mode: Confirm Scan
 rem =============================
 :manualConfirm
-netsh wlan show profiles | findstr "All"
+netsh wlan show profiles | findstr /R /C:"[ ]:[ ]"
 if %errorlevel%==1 goto fail3
 goto mainualContinue
 
@@ -194,7 +194,7 @@ echo # by %dev%
 echo # %tempdivider%
 echo # SSID: %ssidname%
 echo # %tempdivider%
-netsh wlan show profiles name=%ssidname% key=clear | findstr /c:"Key Content" > temp.txt
+netsh wlan show profiles name=%ssidname% key=clear | findstr /N /R /C:":" | findstr 33 > temp.txt
 type temp.txt
 echo # %tempdivider%
 echo # Key content is the password of your target SSID.
@@ -220,7 +220,7 @@ cls
 title %appname% %appvers% - %appstat%
 echo # SSID: %ssidname% >> creds.txt
 echo # %tempdivider% >> creds.txt
-netsh wlan show profiles name=%ssidname% key=clear | findstr /c:"Key Content" >> creds.txt
+netsh wlan show profiles name=%ssidname% key=clear |  findstr /N /R /C:":" | findstr 33 >> creds.txt
 echo # %tempdivider% >> creds.txt
 echo # Key content is the password of your target SSID. >> creds.txt
 echo # %tempdivider% >> creds.txt


### PR DESCRIPTION
Previously, "Key contents" is used to extract passphrase from the console
netsh command. However, Microsoft internally hard-coded i18n elements in
the netsh and could not be reverted to English unless installing
language pack for another Language,
Thus it distracts for this program to parse sementic without making an
effort to translate the keyword

So, intead of keyword, use line number where it print out to the console
to provide service not being affected by i18n.

This feature closes #4
This feature closes #7