### PR TITLE
Fix Landing Page mobile responsiveness

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -97,4 +97,13 @@ nav {
 	html {
 		font-size: 42.5%;
 	}
+
+	.site__h1 {
+		margin-top: 95px;
+	}
+
+	.site__img {
+		max-width: 100%;
+		width: 100%;
+	}
 }


### PR DESCRIPTION
Fixes #32 

Addresses the mobile responsiveness issue by adding two CSS rules for mobile devices. The content should not overlap with the fork corner anymore and the GIF is now properly scaled.

## Before:
![before](https://i.imgur.com/B854AgZ.png)

## After:
![after](https://i.imgur.com/5a6iNkA.png)

## `styles.css`:
```diff
 @media screen and (max-width: 600px) {
	 html {
		 font-size: 42.5%;
	 }
+
+	.site__h1 {
+		margin-top: 95px;
+	}
+
+	.site__img {
+		max-width: 100%;
+		width: 100%;
+	}
 }
```